### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/datatags-app/app/views/comps/modelVersionMetadataTable.scala.html
+++ b/datatags-app/app/views/comps/modelVersionMetadataTable.scala.html
@@ -37,7 +37,7 @@
           <ul>
           @for( ref <- md.getReferences ) {
             <li>
-              @ref.getText @for(doi<-Option(ref.getDoi)){ <small>(doi:<a href="http://dx.doi.org/@doi" target="_blank">@doi</a>)</small>}
+              @ref.getText @for(doi<-Option(ref.getDoi)){ <small>(doi:<a href="https://doi.org/@doi" target="_blank">@doi</a>)</small>}
               @for(url<-Option(ref.getUrl)){
                 <br>
                 <a href="@url" target="_blank">@url</a>


### PR DESCRIPTION
Because of https://github.com/IQSS/dataverse/issues/4469 I thought this code (which is a website template from which new DOI URLs are generated, right?) could be updated as well. I'm not completely sure, though. Please feel free to request changes.